### PR TITLE
Sorting was done on the old system object and not on the new canonica…

### DIFF
--- a/bin/martinize2
+++ b/bin/martinize2
@@ -121,7 +121,7 @@ def pdb_to_universal(system, delete_unknown=False, force_field=None,
         vermouth.pdb.write_pdb(canonicalized, str(write_canon),
                                omit_charges=True, nan_missing_pos=True)
     vermouth.AttachMass(attribute='mass').run_system(canonicalized)
-    vermouth.SortMoleculeAtoms().run_system(system)
+    vermouth.SortMoleculeAtoms().run_system(canonicalized) # was system
     return canonicalized
 
 


### PR DESCRIPTION
…lized object that is actually returned and used everywhere (#231)